### PR TITLE
Feature oauth2 server changes

### DIFF
--- a/yithwebclient/views.py
+++ b/yithwebclient/views.py
@@ -46,7 +46,12 @@ def oauth2cb(request):
                   request.registry.settings['yith_client_secret'])
     response = requests.post(url, data=payload, auth=basic_auth)
     data = response.json()
-    request.session['access_code'] = data['access_code']
+
+    # backwards compatible since the server changed this attribute
+    # from 'access_code' to 'access_token'
+    request.session['access_code'] = data.get('access_token',
+                                              data.get('access_code'))
+
     return HTTPFound(location=request.route_path('list'))
 
 


### PR DESCRIPTION
I'm updating the server to use the oauthlib library instead of a custom implementation because of the following reasons:
- oauthlib supports the 4 major flows of OAuth2. This means more flexibility for clients.
- The rigourness and security of oauthlib is probably better than my own implementation since it is used by a lot more projects than us.

Because of these reasons, there are a couple of small changes needed in the client.

I have tested the client with both versions of the server oauth2 implementation so we can deploy the new client and then the new server without issues.
