### PR TITLE
Python 3 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[easy_install]
+zip_ok = False
+
 [nosetests]
 match = ^test
 nocapture = 1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 
 requires = [
     'pyramid==1.4',
-    'requests==1.2.0',
+    'requests==2.7.0',
     'waitress==0.8.2',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,18 @@ CHANGES = open_file(os.path.join(here, 'CHANGES.rst')).read()
 
 
 requires = [
-    'pyramid==1.4',
+    'PasteDeploy==1.5.2',       # required by pyramid
+    'repoze.lru==0.6',          # required by pyramid
+    'translationstring==1.1',   # required by pyramid
+    'venusian==1.0',            # required by pyramid
+    'WebOb==1.4',               # required by pyramid
+    'zope.interface==4.1.1',    # required by pyramid
+    'Mako==1.0.1',              # required by pyramid_mako
+
+    'pyramid_mako==1.0.2',
+    'pyramid==1.5.4',
     'requests==2.7.0',
-    'waitress==0.8.2',
+    'waitress==0.8.9',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,23 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
+PY3 = sys.version_info[0] == 3
 
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.rst')).read()
-CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
+
+if PY3:
+    def open_file(path):
+        return open(path, encoding='utf-8')
+else:
+    def open_file(path):
+        return open(path)
+
+README = open_file(os.path.join(here, 'README.rst')).read()
+CHANGES = open_file(os.path.join(here, 'CHANGES.rst')).read()
+
 
 requires = [
     'pyramid==1.4',

--- a/yithwebclient/__init__.py
+++ b/yithwebclient/__init__.py
@@ -44,6 +44,9 @@ def main(global_config, **settings):
     settings['ssl_verify'] = read_setting_from_env(settings, 'yith_ssl_ca_bundle', True)
 
     config = Configurator(settings=settings, session_factory=session_factory)
+
+    config.include('pyramid_mako')
+
     config.add_static_view('static', 'static', cache_max_age=3600)
 
     # Routes

--- a/yithwebclient/__init__.py
+++ b/yithwebclient/__init__.py
@@ -41,6 +41,7 @@ def main(global_config, **settings):
         settings[key] = read_setting_from_env(settings, key)
 
     settings['yith_debug'] = asbool(read_setting_from_env(settings, 'yith_debug'))
+    settings['ssl_verify'] = read_setting_from_env(settings, 'yith_ssl_ca_bundle', True)
 
     config = Configurator(settings=settings, session_factory=session_factory)
     config.add_static_view('static', 'static', cache_max_age=3600)

--- a/yithwebclient/tlsadapter.py
+++ b/yithwebclient/tlsadapter.py
@@ -1,0 +1,29 @@
+# Yith Library web client
+# Copyright (C) 2015 Lorenzo Gil Sanchez <lorenzo.gil.sanchez@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import ssl
+
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.poolmanager import PoolManager
+
+
+class TLSv1Adapter(HTTPAdapter):
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = PoolManager(num_pools=connections,
+                                       maxsize=maxsize,
+                                       block=block,
+                                       ssl_version=ssl.PROTOCOL_TLSv1)

--- a/yithwebclient/views.py
+++ b/yithwebclient/views.py
@@ -14,7 +14,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from urllib import urlencode
+import sys
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    from urllib.parse import urlencode
+else:
+    from urllib import urlencode
 
 from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized
 from pyramid.view import view_config

--- a/yithwebclient/views.py
+++ b/yithwebclient/views.py
@@ -30,7 +30,7 @@ import requests
 from yithwebclient.tlsadapter import TLSv1Adapter
 
 requests_session = requests.Session()
-requests_session.mount('https://', TLSv1Adapter)
+requests_session.mount('https://', TLSv1Adapter())
 
 
 @view_config(route_name='index', renderer='index.mak')


### PR DESCRIPTION
The goal of this pull request is to be able to use the client with a server installed with an SSL certificate in a web server with multiple SSL certificates using SNI. For example, connect the client with a server at https://www.yithlibrary.com running on Openshift.

Sadly SNI support in the ssl module of Python is only available starting from Python 2.7.9 and the Python version we have in Openshift is Python 2.7.8. Because of that I decide to add support for Python 3, since Python 3.3 is available in Openshift.

This is actually not very difficult since the majority of the code of the client is Javascript.

The other feature in this PR is the configurable setting of a CA bundle certificate since unless browsers, the openssl library does not trust any CA by default.

@ablanco please take a look.