### PR TITLE
Update configuration for server and client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+- Development configuration now defaults to http://desktopyith:4300.
+  Add desktopyith as a localhost alias in your /etc/hosts.
+
 1.1.2
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,8 @@ completed, you can execute the server with this command::
 
     pserve development.ini
 
-And then the web client will be available at http://localhost:6543/
+And then the web client will be available at http://desktopyith:4300/.
+You need to add desktopyith as a localhost alias in your /etc/hosts.
 
 Build the JavaScript bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/development.ini
+++ b/development.ini
@@ -25,15 +25,16 @@ pyramid.default_locale_name = en
 mako.directories = yithwebclient:templates
 
 yith_debug = true
-yith_server = https://yithlibrary.herokuapp.com
+yith_server = https://www.yithlibrary.com
+#yith_server = http://localhost:6543  # local Yithlibrary server
 #yith_client_id = XXXXXXXXXXXXXXXXXXXX
 #yith_client_secret = ZZZZZZZZZZZZZZZZZZZZ
 #yith_google_analytics = UA-12345678-1
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
-port = 6543
+host = desktopyith
+port = 4300
 
 # Begin logging configuration
 

--- a/production.ini
+++ b/production.ini
@@ -9,7 +9,7 @@ pyramid.default_locale_name = en
 mako.directories = yithwebclient:templates
 
 yith_debug = false
-yith_server = https://yithlibrary.herokuapp.com
+yith_server = https://www.yithlibrary.com
 #yith_client_id = XXXXXXXXXXXXXXXXXXXX
 #yith_client_secret = ZZZZZZZZZZZZZZZZZZZZ
 #yith_google_analytics = UA-12345678-1


### PR DESCRIPTION
All clients bind to http://localyith:4200 by default, and the development Yithlibrary server defaults to http://localhost:6543.

@ablanco @lorenzogil please take a look.
